### PR TITLE
Add timeout when downloading images.

### DIFF
--- a/downloader.py
+++ b/downloader.py
@@ -25,14 +25,16 @@ TITLE = 6
 LICENSE_TEXT = 7
 LICENSE_URL = 8
 
+DOWNLOAD_TIMEOUT_SECS = 2
+
 
 def read_image(url):
 
     try:
-        with urllib.request.urlopen(url) as f:
+        with urllib.request.urlopen(url, timeout = DOWNLOAD_TIMEOUT_SECS) as f:
             return (f.read())
     except urllib.error.URLError as err:
-        pass
+        print("URLError: " + str(err.reason))
     except urllib.error.HTTPError as err:
         print(str(err.code) + " : " + str(err.reason))
         if err.code == 429:

--- a/downloader_threads.py
+++ b/downloader_threads.py
@@ -30,6 +30,7 @@ LICENSE_URL = 8
 
 THREADS = 8
 
+DOWNLOAD_TIMEOUT_SECS = 2
 
 def chunks(l, n):
     index_list = np.linspace(0, len(l), n + 1)
@@ -40,10 +41,10 @@ def chunks(l, n):
 def read_image(url):
 
     try:
-        with urllib.request.urlopen(url) as f:
+        with urllib.request.urlopen(url, timeout = DOWNLOAD_TIMEOUT_SECS) as f:
             return (f.read())
     except urllib.error.URLError as err:
-        pass
+        print("URLError: " + str(err.reason))
     except urllib.error.HTTPError as err:
         print(str(err.code) + " : " + str(err.reason))
         if err.code == 429:


### PR DESCRIPTION
The `urllib` library has no timeout by default, so when fetching a URL hangs, it hangs forever: https://stackoverflow.com/questions/29649173/what-is-the-global-default-timeout.

In this script, without the timeout, each thread eventually encounters a URL which hangs, and that thread stops downloading images. Once all threads encounter such a bad URL, all downloading stops and the script must be restarted.

With the timeout, the script is able to skip over images which cause downloading to hang.